### PR TITLE
refactor: recovery failed chan and recovery

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,16 +2,43 @@ package clarimq
 
 import (
 	"errors"
+	"fmt"
+
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-// ErrNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
-var ErrNoActiveConnection = errors.New("no active connection to rabbitmq")
+// errNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
+var errNoActiveConnection = errors.New("no active connection to rabbitmq")
 
 // ErrMaxRetriesExceeded occurs when the maximum number of retries exceeds.
 var ErrMaxRetriesExceeded = errors.New("max retries exceeded")
 
-// ErrHealthyConnection occurs if a manual reconnect is triggered but the connection persists.
+// ErrHealthyConnection occurs when a manual reconnect is triggered but the connection persists.
 var ErrHealthyConnection = errors.New("connection is healthy, no need to reconnect")
 
-// ErrInvalidConnection when an invalid connection is passed to a publisher or a consumer.
+// ErrInvalidConnection occurs when an invalid connection is passed to a publisher or a consumer.
 var ErrInvalidConnection = errors.New("invalid connection")
+
+type AMQPError amqp.Error
+
+func (e *AMQPError) Error() string {
+	return fmt.Sprintf("Exception (%d) Reason: %q", e.Code, e.Reason)
+}
+
+// ErrRecoveryFailed occurs when the recovery failed after a connection loss.
+type RecoveryFailedError struct {
+	Err error
+}
+
+// Error implements the Error method of the error interface.
+func (e *RecoveryFailedError) Error() string {
+	var str string
+
+	if e.Err != nil {
+		str = e.Err.Error()
+	} else {
+		str = "unknown error"
+	}
+
+	return str
+}

--- a/errors.go
+++ b/errors.go
@@ -7,8 +7,11 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-// errNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
-var errNoActiveConnection = errors.New("no active connection to rabbitmq")
+// ErrNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
+var ErrNoActiveConnection = errors.New("no active connection to rabbitmq")
+
+// ErrChannelClosed occurs when the channel accessed but is closed.
+var ErrChannelClosed = errors.New("amqp channel is closed")
 
 // ErrMaxRetriesExceeded occurs when the maximum number of retries exceeds.
 var ErrMaxRetriesExceeded = errors.New("max retries exceeded")


### PR DESCRIPTION
- Changes the purpose of the "recovery failed chan" to a general err chan, which report all errors that happen concurrently.
- Refactors the recovery to consider all conceivable cases. The connection and channel recovery now run completely independently of each other.
- Fixes some race conditions
- Adds backoff to initial connection attempt