### PR TITLE
feat: add publishing cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,9 +10,6 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
   
-env:
-  GO_VERSION: 1.21
-
 jobs:
   ci:
     name: Vet, lint and test
@@ -24,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ">=1.21.0"
 
     - name: Vet
       run: make vet
@@ -52,5 +49,4 @@ jobs:
     - id: govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: ${{ env.GO_VERSION }}
         go-package: ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,11 +36,11 @@ jobs:
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
         golangci-lint run --out-format=github-actions
 
-    - name: Integration Test
+    - name: Integration Tests
       run: make test_integration
     
-    - name: Reconnection Test
-      run: make test_reconnection
+    - name: Recovery Tests
+      run: make test_recovery
 
   govulncheck:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ vuln:
 	govulncheck ./...
 
 test:
-	go test -skip "(Test_Integration|Test_Reconnection)" -vet=off -failfast -race -coverprofile=coverage.out
+	go test -skip "(Test_Integration|Test_Recovery)" -vet=off -failfast -race -coverprofile=coverage.out
 
 test_integration:
 	./run_integration_tests.sh Test_Integration
 
-test_reconnection:
-	./run_integration_tests.sh Test_Reconnection
+test_recovery:
+	./run_integration_tests.sh Test_Recovery
 
-test_all: test test_integration test_reconnection
+test_all: test test_integration test_recovery

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ When the Publishing Cache is **not set**, the "Publish" and "PublishWithOptions"
 
 To ensure a clean cache (when using an external cache like f.e. redis) the publisher should be closed when exiting. This will call the "Flush()" method of the Publishing Cache implementation. This step is optional and it up to the user to decide.
 
-When implementing the publishing cache, the it must be properly protected from concurrent access by multiple publisher instances to avoid race conditions.
+When implementing the publishing cache, it must be properly protected from concurrent access by multiple publisher instances to avoid race conditions.
 
 _Hint: The "cache" sub-package provides a simple "in-memory-cache" implementation, that can be used for testing, but could also be used in production._
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,24 @@ go get github.com/Clarilab/clarimq
 
 First a connection instance needs to be initialized.
 The connection can be configured by passing needed connection options.
-Also there is the possibility to fully customize the configuration by passing a *ConnectionOptions* struct with the corresponding option.
-To ensure correct escaping of the URI, the *SettingsToURI* function can be used to convert a *ConnectionSettings* struct to a valid URI.
+Also there is the possibility to fully customize the configuration by passing a **ConnectionOptions** struct with the corresponding option.
+To ensure correct escaping of the URI, the **SettingsToURI** function can be used to convert a **ConnectionSettings** struct to a valid URI.
 
 #### Note:
-*Although it is possible to publish and consume with one connection, it is best practice to use two separate connections for publisher and consumer activities.*
+_Although it is possible to publish and consume with one connection, it is best practice to use two separate connections for publisher and consumer activities._
 
-##### Connection with some options:
+##### Example: Connection with some options:
 ```Go
-conn := clarimq.NewConnection("amqp://admin:password@localhost:5672/", 
-	clarimq.WithConnectionOptionConnectionName(service-name),
+conn, err := clarimq.NewConnection("amqp://user:password@localhost:5672/", 
+	clarimq.WithConnectionOptionConnectionName("app-name-connection"),
 	// more options can be passed
 )
+if err != nil {
+	// handle error
+}
 ```
 
-##### Connection with custom options:
+##### Example: Connection with custom options:
 ```Go
 connectionSettings := &clarimq.ConnectionSettings{
 	UserName: "username",
@@ -59,14 +62,58 @@ connectionOptions := &clarimq.ConnectionOptions{
 	ReconnectInterval: 1,
 },
 
-conn := clarimq.NewConnection(clarimq.SettingsToURI(connectionSettings), 
+conn, err := clarimq.NewConnection(clarimq.SettingsToURI(connectionSettings), 
 	clarimq.WithCustomConnectionOptions(connectionOptions),
 )
+if err != nil {
+	// handle error
+}
 ```
 
 When the connection is no longer needed, it should be closed to conserve resources.
+
+##### Example: 
 ```Go
-conn.Close()
+if err := conn.Close(); err != nil {
+	// handle error
+}
+```
+
+### Errors
+
+The "NotifyErrors()" method provides a channel that returns any errors that may happen concurrently. Mainly custom errors of types **clarimq.AMQPError** and **clarimq.RecoveryFailedError** are returned.
+
+
+##### Example: 
+```Go
+handleErrors := func(errChan <-chan error) {
+	for err := range errChan {
+		if err == nil {
+			return
+		}
+
+		var amqpErr *clarimq.AMQPError
+		var recoveryFailed *clarimq.RecoveryFailedError
+
+		switch {
+		case errors.As(err, &amqpErr):
+			fmt.Println(amqpErr) // handle amqp error
+ 
+		case errors.As(err, &recoveryFailed):
+			fmt.Println(recoveryFailed) // handle recoveryFailed error
+
+		default:
+			panic(err) // handle all other errors
+		}
+	}
+}
+
+conn, err := clarimq.NewConnection(clarimq.SettingsToURI(settings))
+if err != nil {
+	// handle error
+}
+
+go handleFailedRecovery(conn.NotifyErrors())
 ```
 
 ### Publish messages
@@ -74,8 +121,9 @@ conn.Close()
 To publish messages a publisher instance needs to be created. A previously created connection must be handed over to the publisher.
 
 The publisher can be configured by passing needed connector options.
-Also there is the possibility to fully customize the configuration by passing a *PublishOptions* struct with the corresponding option. 
+Also there is the possibility to fully customize the configuration by passing a **PublishOptions** struct with the corresponding option. 
 
+##### Example:
 ```Go
 publisher, err := clarimq.NewPublisher(conn,
 	clarimq.WithPublishOptionAppID("my-application"),
@@ -89,27 +137,24 @@ if err != nil {
 The publisher can then be used to publish messages.
 The target can be a queue name, or a topic if the publisher is configured to publish messages to an exchange.
 
-Simple publish:
+##### Example: Simple publish:
 ```Go
-err = publisher.Publish(context.Background(), "my-target", "my-message")
-if err != nil {
+if err := publisher.Publish(context.Background(), "my-target", "my-message"); err != nil {
 	// handle error
 }
 ```
 
-Optionally the *PublishWithOptions* method can be used to configure the publish options just for this specific publish.
+Optionally the **PublishWithOptions** method can be used to configure the publish options just for this specific publish.
 The Method also gives the possibility to publish to multiple targets at once.
 
-Publish with options:
+##### Example: Publish with options:
 ```Go
-err = publisher.PublishWithOptions(context.Background(), []string{"my-target-1","my-target-2"}, "my-message",
+if err := publisher.PublishWithOptions(context.Background(), []string{"my-target-1","my-target-2"}, "my-message",
 	clarimq.WithPublishOptionMessageID("99819a3a-388f-4199-b7e6-cc580d85a2e5"),
 	clarimq.WithPublishOptionTracing("7634e958-1509-479e-9246-5b80ad8fc64c"),
-)
-if err != nil {
+); err != nil {
 	// handle error
 }
-return nil
 ```
 
 ### Consume Messages
@@ -117,10 +162,11 @@ return nil
 To consume messages a consumer instance needs to be created. A previously created connection must be handed over to the consumer.
 
 The consumer can be configured by passing needed consume options.
-Also there is the possibility to fully customize the configuration by passing a *ConsumeOptions* struct with the corresponding option. 
+Also there is the possibility to fully customize the configuration by passing a **ConsumeOptions** struct with the corresponding option. 
 
+##### Example: 
 ```Go
-consumer, err = clarimq.NewConsumer(conn, "my-queue", handler(),
+consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
 		clarimq.WithConsumerOptionConsumerName("my-consumer"),
 	// more options can be passed
 )
@@ -130,28 +176,34 @@ if err != nil {
 ```
 
 The consumer can be used to declare exchanges, queues and queue-bindings:
+
+##### Example: 
 ```Go
 consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
-		clarimq.WithConsumerOptionConsumerName("my-consumer"),
-		clarimq.WithExchangeOptionDeclare(true),
-		clarimq.WithExchangeOptionKind(clarimq.ExchangeTopic),
-		clarimq.WithExchangeOptionName("my-exchange"),
-		clarimq.WithQueueOptionDeclare(false), // is enabled by default, can be used to disable the default behavior
-		clarimq.WithConsumerOptionBinding(
-			clarimq.Binding{
-				RoutingKey: "my-routing-key",
-			},
-		),
-		// more options can be passed
-	)
-	if err != nil {
-		// handle error
-	}
+	clarimq.WithConsumerOptionConsumerName("my-consumer"),
+	clarimq.WithExchangeOptionDeclare(true),
+	clarimq.WithExchangeOptionKind(clarimq.ExchangeTopic),
+	clarimq.WithExchangeOptionName("my-exchange"),
+	clarimq.WithQueueOptionDeclare(false), // is enabled by default, can be used to disable the default behavior
+	clarimq.WithConsumerOptionBinding(
+		clarimq.Binding{
+			RoutingKey: "my-routing-key",
+		},
+	),
+	// more options can be passed
+)
+if err != nil {
+	// handle error
+}
 ```
 
 The consumer can be closed to stop consuming if needed. The consumer does not need to be explicitly closed for a graceful shutdown if its connection is closed afterwards. However when using the retry functionality without providing a connection, the consumer must be closed for a graceful shutdown of the retry connection to conserve resources.
+
+##### Example: 
 ```Go
-consumer.Close()
+if err := consumer.Close(); err != nil {
+	// handle error
+}
 ```
 
 ### Logging:
@@ -161,15 +213,19 @@ The logs are written to a io.Writer that also can be specified.
 
 Note: Multiple loggers can be specified!
 
+##### Example:
 ```Go
 jsonBuff := new(bytes.Buffer)
 textBuff := new(bytes.Buffer)
 
-conn := clarimq.NewConnection(connectionSettings, 
+conn, err := clarimq.NewConnection(connectionSettings, 
 	clarimq.WithConnectionOptionTextLogging(os.Stdout, slog.LevelInfo),
 	clarimq.WithConnectionOptionTextLogging(textBuff, slog.LevelWarn),
 	clarimq.WithConnectionOptionJSONLogging(jsonBuff, slog.LevelDebug),
 )
+if err != nil {
+	// handle error
+}
 ```
 
 ### Return Handler:
@@ -177,64 +233,89 @@ When publishing mandatory messages, they will be returned if it is not possible 
 
 If no return handler is specified a log will be written to the logger at warn level.
 
+##### Example: 
 ```Go
 returnHandler := func(r clarimq.Return) {
 	// handle the return
 }
 
-conn := clarimq.NewConnection(connectionSettings, 
+conn, err := clarimq.NewConnection(connectionSettings, 
 	clarimq.WithConnectionOptionReturnHandler(
 		clarimq.ReturnHandler(returnHandler),
 	),
 )
+if err != nil {
+	// handle error
+}
 ```
 
 ### Recovery:
 
-This library provides an automatic recovery with build-in exponential back-off functionality. When the connection to the server is lost, the recovery will automatically try to reconnect. You can adjust the parameters of the back-off algorithm:
+This library provides an automatic recovery with build-in exponential back-off functionality. When the connection to the broker is lost, the recovery will automatically try to reconnect. You can adjust the parameters of the back-off algorithm:
 
+##### Example: 
 ```Go
-conn, err = clarimq.NewConnection(settings,
+conn, err := clarimq.NewConnection(settings,
 	clarimq.WithConnectionOptionReconnectInterval(2),    // default is 1 second
 	clarimq.WithConnectionOptionBackOffFactor(3),        // default is 2
 	clarimq.WithConnectionOptionMaxReconnectRetries(16), // default is 10
 )
+if err != nil {
+	// handle error
+}
 ```
 
-For the case the maximum number of retries is reached, the connection provides a *NotifyAutoRecoveryFail* method which provides a channel that will return an error for you to handle:
+For the case the maximum number of retries is reached, a custom error of type **RecoveryFailedError** will be send to the error channel.
 
+
+### Publishing Cache:
+
+To prevent loosing messages from being published while the broker has downtime / the client is recovering, the Publishing Cache can be used to cache the messages and publish them as soon as the client is fully recovered. The cache itself is an interface that can be implemented to the users needs. For example it could be implemented to use a redis store or any other storage of choice.
+
+_Note: This feature will only work effectively if durable queues/exchanges are used!_
+
+When the Publishing Cache is **set**, the "Publish" and "PublishWithOptions" methods will return an **clarimq.ErrPublishFailedChannelClosedCached** error which can be checked and handled to the users needs. 
+
+When the Publishing Cache is **not set**, the "Publish" and "PublishWithOptions" methods will return an **clarimq.ErrPublishFailedChannelClosed** error which can be checked and handled to the users needs. 
+
+To ensure a clean cache (when using an external cache like f.e. redis) the publisher should be closed when exiting. This will call the "Flush()" method of the Publishing Cache implementation. This step is optional and it up to the user to decide.
+
+_Hint: The "cache" sub-package provides a simple "in-memory-cache" implementation, that can be used for testing, but could also be used in production._
+
+##### Example:
 ```Go
-handleFailedRecovery := func(failedRecovery <-chan error) {
-	for err := range failedRecovery {
-		if err != nil {
-			// handle failed recovery
-		}
-	}
+publisher, err = clarimq.NewPublisher(publishConn,
+	clarimq.WithPublisherOptionPublishingCache(cache.NewBasicMemoryCache()),
+)
+if err != nil {
+	// handle error
 }
 
-conn, err = clarimq.NewConnection(settings)
+defer func() {
+	if err := publisher.Close(); err != nil {
+		// handle error
+	}
+}()
 
-handleFailedRecovery(conn.NotifyAutoRecoveryFail())
+if err = b.publisher.PublishWithOptions(context.Background(), "my-target", "my-message",); err != nil {
+	switch {
+		case errors.Is(err, clarimq.ErrPublishFailedChannelClosedCached):
+			return nil // message has been cached
+		case errors.Is(err, clarimq.ErrPublishFailedChannelClosed):
+			return err
+		default:
+			panic(err)
+	}
+}
 ```
 
 ### Retry:
 
 This library includes a retry functionality with a dead letter exchange and dead letter queues. To use the retry, some parameters have to be set:
 
+##### Example:
 ```Go
-connectionSettings := &clarimq.ConnectionSettings{
-	UserName: "username",
-	Password: "password",
-	Host:     "host",
-	Port:     5672,
-}
-
-publishConn, err := clarimq.NewConnection(clarimq.SettingsToURI(connectionSettings))
-if err != nil {
-	// handle error
-}
-
-consumeConn, err := clarimq.NewConnection(clarimq.SettingsToURI(connectionSettings))
+consumeConn, err := clarimq.NewConnection(clarimq.SettingsToURI(settings))
 if err != nil {
 	// handle error
 }
@@ -255,6 +336,9 @@ retryOptions := &clarimq.RetryOptions{
 consumer, err := clarimq.NewConsumer(consumeConn, queueName, handler,
 		clarimq.WithConsumerOptionDeadLetterRetry(retryOptions),
 	)
+if err != nil {
+	// handle error
+}
 ```
 
 It is recommended to provide a separate publish connection for the retry functionality. If no connection is specified, a separate connection is established internally. 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This library is a wrapper around the [Go AMQP Client Library](https://github.com/rabbitmq/amqp091-go).
 
-This library also includes support for:
+This library includes support for:
 - structured logging to multiple writers
 - automatic recovery
 - retry functionality
+- publishing cache
 
 Supported Go Versions
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ When the Publishing Cache is **not set**, the "Publish" and "PublishWithOptions"
 
 To ensure a clean cache (when using an external cache like f.e. redis) the publisher should be closed when exiting. This will call the "Flush()" method of the Publishing Cache implementation. This step is optional and it up to the user to decide.
 
+When implementing the publishing cache, the it must be properly protected from concurrent access by multiple publisher instances to avoid race conditions.
+
 _Hint: The "cache" sub-package provides a simple "in-memory-cache" implementation, that can be used for testing, but could also be used in production._
 
 ##### Example:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To ensure correct escaping of the URI, the **SettingsToURI** function can be use
 #### Note:
 _Although it is possible to publish and consume with one connection, it is best practice to use two separate connections for publisher and consumer activities._
 
-##### Example: Connection with some options:
+##### Example Connection with some options:
 ```Go
 conn, err := clarimq.NewConnection("amqp://user:password@localhost:5672/", 
 	clarimq.WithConnectionOptionConnectionName("app-name-connection"),
@@ -41,7 +41,7 @@ if err != nil {
 }
 ```
 
-##### Example: Connection with custom options:
+##### Example Connection with custom options:
 ```Go
 connectionSettings := &clarimq.ConnectionSettings{
 	UserName: "username",
@@ -73,7 +73,7 @@ if err != nil {
 
 When the connection is no longer needed, it should be closed to conserve resources.
 
-##### Example: 
+##### Example 
 ```Go
 if err := conn.Close(); err != nil {
 	// handle error
@@ -85,7 +85,7 @@ if err := conn.Close(); err != nil {
 The "NotifyErrors()" method provides a channel that returns any errors that may happen concurrently. Mainly custom errors of types **clarimq.AMQPError** and **clarimq.RecoveryFailedError** are returned.
 
 
-##### Example: 
+##### Example 
 ```Go
 handleErrors := func(errChan <-chan error) {
 	for err := range errChan {
@@ -124,7 +124,7 @@ To publish messages a publisher instance needs to be created. A previously creat
 The publisher can be configured by passing needed connector options.
 Also there is the possibility to fully customize the configuration by passing a **PublishOptions** struct with the corresponding option. 
 
-##### Example:
+##### Example
 ```Go
 publisher, err := clarimq.NewPublisher(conn,
 	clarimq.WithPublishOptionAppID("my-application"),
@@ -138,7 +138,7 @@ if err != nil {
 The publisher can then be used to publish messages.
 The target can be a queue name, or a topic if the publisher is configured to publish messages to an exchange.
 
-##### Example: Simple publish:
+##### Example Simple publish:
 ```Go
 if err := publisher.Publish(context.Background(), "my-target", "my-message"); err != nil {
 	// handle error
@@ -148,7 +148,7 @@ if err := publisher.Publish(context.Background(), "my-target", "my-message"); er
 Optionally the **PublishWithOptions** method can be used to configure the publish options just for this specific publish.
 The Method also gives the possibility to publish to multiple targets at once.
 
-##### Example: Publish with options:
+##### Example Publish with options:
 ```Go
 if err := publisher.PublishWithOptions(context.Background(), []string{"my-target-1","my-target-2"}, "my-message",
 	clarimq.WithPublishOptionMessageID("99819a3a-388f-4199-b7e6-cc580d85a2e5"),
@@ -165,7 +165,7 @@ To consume messages a consumer instance needs to be created. A previously create
 The consumer can be configured by passing needed consume options.
 Also there is the possibility to fully customize the configuration by passing a **ConsumeOptions** struct with the corresponding option. 
 
-##### Example: 
+##### Example 
 ```Go
 consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
 		clarimq.WithConsumerOptionConsumerName("my-consumer"),
@@ -178,7 +178,7 @@ if err != nil {
 
 The consumer can be used to declare exchanges, queues and queue-bindings:
 
-##### Example: 
+##### Example 
 ```Go
 consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
 	clarimq.WithConsumerOptionConsumerName("my-consumer"),
@@ -200,7 +200,7 @@ if err != nil {
 
 The consumer can be closed to stop consuming if needed. The consumer does not need to be explicitly closed for a graceful shutdown if its connection is closed afterwards. However when using the retry functionality without providing a connection, the consumer must be closed for a graceful shutdown of the retry connection to conserve resources.
 
-##### Example: 
+##### Example 
 ```Go
 if err := consumer.Close(); err != nil {
 	// handle error
@@ -214,7 +214,7 @@ The logs are written to a io.Writer that also can be specified.
 
 Note: Multiple loggers can be specified!
 
-##### Example:
+##### Example
 ```Go
 jsonBuff := new(bytes.Buffer)
 textBuff := new(bytes.Buffer)
@@ -234,7 +234,7 @@ When publishing mandatory messages, they will be returned if it is not possible 
 
 If no return handler is specified a log will be written to the logger at warn level.
 
-##### Example: 
+##### Example 
 ```Go
 returnHandler := func(r clarimq.Return) {
 	// handle the return
@@ -254,7 +254,7 @@ if err != nil {
 
 This library provides an automatic recovery with build-in exponential back-off functionality. When the connection to the broker is lost, the recovery will automatically try to reconnect. You can adjust the parameters of the back-off algorithm:
 
-##### Example: 
+##### Example 
 ```Go
 conn, err := clarimq.NewConnection(settings,
 	clarimq.WithConnectionOptionRecoveryInterval(2),    // default is 1 second
@@ -285,9 +285,9 @@ When implementing the publishing cache, it must be properly protected from concu
 
 _Hint: The "cache" sub-package provides a simple "in-memory-cache" implementation, that can be used for testing, but could also be used in production._
 
-##### Example:
+##### Example
 ```Go
-publisher, err = clarimq.NewPublisher(publishConn,
+publisher, err := clarimq.NewPublisher(publishConn,
 	clarimq.WithPublisherOptionPublishingCache(cache.NewBasicMemoryCache()),
 )
 if err != nil {
@@ -316,7 +316,7 @@ if err = b.publisher.PublishWithOptions(context.Background(), "my-target", "my-m
 
 This library includes a retry functionality with a dead letter exchange and dead letter queues. To use the retry, some parameters have to be set:
 
-##### Example:
+##### Example
 ```Go
 consumeConn, err := clarimq.NewConnection(clarimq.SettingsToURI(settings))
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library also includes support for:
 
 Supported Go Versions
 
-This library supports the most recent Go, currently 1.21
+This library supports the most recent Go, currently 1.21.1
 
 ## INSTALL
 
@@ -59,7 +59,7 @@ connectionOptions := &clarimq.ConnectionOptions{
 		Locale:          "",
 	},
 	PrefetchCount:     1,
-	ReconnectInterval: 1,
+	RecoveryInterval: 1,
 },
 
 conn, err := clarimq.NewConnection(clarimq.SettingsToURI(connectionSettings), 
@@ -256,9 +256,9 @@ This library provides an automatic recovery with build-in exponential back-off f
 ##### Example: 
 ```Go
 conn, err := clarimq.NewConnection(settings,
-	clarimq.WithConnectionOptionReconnectInterval(2),    // default is 1 second
+	clarimq.WithConnectionOptionRecoveryInterval(2),    // default is 1 second
 	clarimq.WithConnectionOptionBackOffFactor(3),        // default is 2
-	clarimq.WithConnectionOptionMaxReconnectRetries(16), // default is 10
+	clarimq.WithConnectionOptionMaxRecoveryRetries(16), // default is 10
 )
 if err != nil {
 	// handle error

--- a/amqp.go
+++ b/amqp.go
@@ -14,7 +14,7 @@ const (
 const (
 	// Ack default ack this msg after you have successfully processed this delivery.
 	Ack Action = iota
-	// NackDiscard the message will be dropped or delivered to a server configured dead-letter queue.
+	// NackDiscard the message will be dropped or delivered to a broker configured dead-letter queue.
 	NackDiscard
 	// NackRequeue deliver this message to a different consumer.
 	NackRequeue
@@ -60,7 +60,7 @@ type (
 	// Action is an action that occurs after processed this delivery.
 	Action int
 
-	// Return captures a flattened struct of fields returned by the server when a Publishing is unable
+	// Return captures a flattened struct of fields returned by the broker when a publishing is unable
 	// to be delivered due to the `mandatory` flag set and no route found.
 	Return amqp.Return
 

--- a/binding.go
+++ b/binding.go
@@ -19,7 +19,7 @@ type (
 	BindingOptions struct {
 		// Are used by plugins and broker-specific features such as message TTL, queue length limit, etc.
 		Args Table
-		// If true, the client does not wait for a reply method. If the server could not complete the method it will raise a channel or connection exception.
+		// If true, the client does not wait for a reply method. If the broker could not complete the method it will raise a channel or connection exception.
 		NoWait bool
 		// If true, the binding will be declared if it does not already exist.
 		Declare bool
@@ -58,14 +58,13 @@ func declareBindings(channel *amqp.Channel, queueName, exchangeName string, bind
 			continue
 		}
 
-		err := channel.QueueBind(
+		if err := channel.QueueBind(
 			binding.defaultQueueNameOr(queueName),
 			binding.RoutingKey,
 			binding.defaultExchangeNameOr(exchangeName),
 			binding.NoWait,
 			amqp.Table(binding.Args),
-		)
-		if err != nil {
+		); err != nil {
 			return fmt.Errorf(errMessage, err)
 		}
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,12 +1,15 @@
 package cache
 
 import (
+	"sync"
+
 	"github.com/Clarilab/clarimq"
 )
 
 // BasicInMemoryCache is a basic in-memory cache implementation of the clarimq.PublishingCache interface.
 type BasicInMemoryCache struct {
-	store map[string]clarimq.Publishing
+	storeMU sync.Mutex
+	store   map[string]clarimq.Publishing
 }
 
 // NewBasicMemoryCache creates a new in-memory cache.
@@ -18,7 +21,9 @@ func NewBasicMemoryCache() *BasicInMemoryCache {
 
 // Put implements the clarimq.PublishingCache interface.
 func (c *BasicInMemoryCache) Put(pbl clarimq.Publishing) error {
+	c.storeMU.Lock()
 	c.store[pbl.ID()] = pbl
+	c.storeMU.Unlock()
 
 	return nil
 }
@@ -27,25 +32,34 @@ func (c *BasicInMemoryCache) Put(pbl clarimq.Publishing) error {
 func (c *BasicInMemoryCache) PopAll() ([]clarimq.Publishing, error) {
 	data := make([]clarimq.Publishing, 0, len(c.store))
 
+	c.storeMU.Lock()
 	for key, val := range c.store {
 		data = append(data, val)
 
 		delete(c.store, key)
 	}
 
+	c.storeMU.Unlock()
+
 	return data, nil
 }
 
 // Len implements the clarimq.PublishingCache interface.
 func (c *BasicInMemoryCache) Len() int {
+	c.storeMU.Lock()
+	defer c.storeMU.Unlock()
+
 	return len(c.store)
 }
 
 // Flush implements the clarimq.PublishingCache interface.
 func (c *BasicInMemoryCache) Flush() error {
+	c.storeMU.Lock()
 	for key := range c.store {
 		delete(c.store, key)
 	}
+
+	c.storeMU.Unlock()
 
 	return nil
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"github.com/Clarilab/clarimq"
+)
+
+// BasicInMemoryCache is a basic in-memory cache implementation of the clarimq.PublishingCache interface.
+type BasicInMemoryCache struct {
+	store map[string]clarimq.Publishing
+}
+
+// NewBasicMemoryCache creates a new in-memory cache.
+func NewBasicMemoryCache() *BasicInMemoryCache {
+	return &BasicInMemoryCache{
+		store: make(map[string]clarimq.Publishing),
+	}
+}
+
+// Put implements the clarimq.PublishingCache interface.
+func (c *BasicInMemoryCache) Put(pbl clarimq.Publishing) error {
+	c.store[pbl.ID()] = pbl
+
+	return nil
+}
+
+// PopAll implements the clarimq.PublishingCache interface.
+func (c *BasicInMemoryCache) PopAll() ([]clarimq.Publishing, error) {
+	data := make([]clarimq.Publishing, 0, len(c.store))
+
+	for key, val := range c.store {
+		data = append(data, val)
+
+		delete(c.store, key)
+	}
+
+	return data, nil
+}
+
+// Len implements the clarimq.PublishingCache interface.
+func (c *BasicInMemoryCache) Len() int {
+	return len(c.store)
+}
+
+// Flush implements the clarimq.PublishingCache interface.
+func (c *BasicInMemoryCache) Flush() error {
+	for key := range c.store {
+		delete(c.store, key)
+	}
+
+	return nil
+}

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -1258,11 +1258,13 @@ func Test_Reconnection_AutomaticReconnect(t *testing.T) { //nolint:paralleltest 
 	publishConn := getConnection(t,
 		clarimq.WithConnectionOptionJSONLogging(publishConnLogBuffer, slog.LevelDebug),
 		clarimq.WithConnectionOptionBackOffFactor(1),
+		clarimq.WithConnectionOptionReconnectInterval(500*time.Millisecond),
 	)
 
 	consumeConn := getConnection(t,
 		clarimq.WithConnectionOptionJSONLogging(consumeConnLogBuffer, slog.LevelDebug),
 		clarimq.WithConnectionOptionBackOffFactor(1),
+		clarimq.WithConnectionOptionReconnectInterval(500*time.Millisecond),
 	)
 
 	t.Cleanup(func() {
@@ -1310,7 +1312,7 @@ func Test_Reconnection_AutomaticReconnect(t *testing.T) { //nolint:paralleltest 
 	requireEqual(t, 1, msgCounter)
 
 	// shutting down the rabbitmq container to simulate a connection loss.
-	err = exec.Command("docker", "compose", "down", "rabbitmq").Run()
+	err = exec.Command("docker", "compose", "stop", "rabbitmq").Run()
 	requireNoError(t, err)
 
 	// bringing the rabbitmq container up again.
@@ -1444,7 +1446,7 @@ func Test_Reconnection_AutomaticReconnectFailedTryManualReconnect(t *testing.T) 
 	requireEqual(t, 1, msgCounter)
 
 	// shutting down the rabbitmq container to simulate a connection loss.
-	err = exec.Command("docker", "compose", "down", "rabbitmq").Run()
+	err = exec.Command("docker", "compose", "stop", "rabbitmq").Run()
 	requireNoError(t, err)
 
 	// waiting for the failed recovery notification to finish handling.

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -227,7 +227,7 @@ func Test_Integration_PublishToExchange(t *testing.T) {
 			)
 			requireNoError(t, err)
 
-			err = publisher.Publish(context.TODO(), testParams.routingKey, test.message)
+			err = publisher.Publish(context.Background(), testParams.routingKey, test.message)
 			requireNoError(t, err)
 
 			<-doneChan
@@ -275,7 +275,7 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, target string) error {
-				return p.PublishWithOptions(context.TODO(), []string{target}, message)
+				return p.PublishWithOptions(context.Background(), []string{target}, message)
 			},
 		},
 		"publish to queue passive": {
@@ -299,7 +299,7 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, target string) error {
-				return p.PublishWithOptions(context.TODO(), []string{target}, message)
+				return p.PublishWithOptions(context.Background(), []string{target}, message)
 			},
 			passiveQueue: true,
 		},
@@ -324,7 +324,7 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, target string) error {
-				return p.PublishWithOptions(context.TODO(), []string{target}, message)
+				return p.PublishWithOptions(context.Background(), []string{target}, message)
 			},
 		},
 		"publish to priority queue": {
@@ -349,7 +349,7 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, target string) error {
-				return p.PublishWithOptions(context.TODO(), []string{target}, message, clarimq.WithPublishOptionPriority(clarimq.HighPriority))
+				return p.PublishWithOptions(context.Background(), []string{target}, message, clarimq.WithPublishOptionPriority(clarimq.HighPriority))
 			},
 		},
 		"publish to durable queue": {
@@ -373,7 +373,7 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, target string) error {
-				return p.PublishWithOptions(context.TODO(), []string{target}, message)
+				return p.PublishWithOptions(context.Background(), []string{target}, message)
 			},
 		},
 	}
@@ -673,7 +673,7 @@ func Test_Integration_Consume(t *testing.T) {
 			)
 			requireNoError(t, err)
 
-			err = publisher.Publish(context.TODO(), testParams.routingKey, message)
+			err = publisher.Publish(context.Background(), testParams.routingKey, message)
 			requireNoError(t, err)
 
 			<-doneChan
@@ -735,7 +735,7 @@ func Test_Integration_CustomOptions(t *testing.T) {
 				)
 			},
 			publish: func(p *clarimq.Publisher, targets []string) error {
-				return p.PublishWithOptions(context.TODO(), targets, message)
+				return p.PublishWithOptions(context.Background(), targets, message)
 			},
 		},
 		"publish with custom options": {
@@ -772,7 +772,7 @@ func Test_Integration_CustomOptions(t *testing.T) {
 			},
 			publish: func(p *clarimq.Publisher, targets []string) error {
 				return p.PublishWithOptions(
-					context.TODO(),
+					context.Background(),
 					targets,
 					message,
 					clarimq.WithCustomPublishOptions(
@@ -1030,7 +1030,7 @@ func Test_Integration_ReturnHandler(t *testing.T) {
 	requireNoError(t, err)
 
 	// publishing a mandatory message with a routing key with out the existence of a binding.
-	err = publisher.Publish(context.TODO(), "does-not-exist", message)
+	err = publisher.Publish(context.Background(), "does-not-exist", message)
 	requireNoError(t, err)
 
 	// the publishing is retured to the return handler.

--- a/connection_options.go
+++ b/connection_options.go
@@ -37,15 +37,15 @@ type (
 		BackOffFactor       int
 	}
 
-	// ConnectionSettings holds settings for a RabbitMQ connection.
+	// ConnectionSettings holds settings for a broker connection.
 	ConnectionSettings struct {
-		// UserName contains the username of the RabbitMQ user.
+		// UserName contains the username of the broker user.
 		UserName string
-		// Password contains the password of the RabbitMQ user.
+		// Password contains the password of the broker user.
 		Password string
-		// Host contains the hostname or ip of the RabbitMQ server.
+		// Host contains the hostname or ip of the broker.
 		Host string
-		// Post contains the port number the RabbitMQ server is listening on.
+		// Post contains the port number the broker is listening on.
 		Port int
 	}
 

--- a/connection_options.go
+++ b/connection_options.go
@@ -17,6 +17,7 @@ const (
 )
 
 type (
+	// ConnectionOption is an option for a Connection.
 	ConnectionOption func(*ConnectionOptions)
 
 	// Config is used in DialConfig and Open to specify the desired tuning

--- a/connection_options.go
+++ b/connection_options.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	defaultReconnectInterval   time.Duration = time.Second
-	defaultMaxReconnectRetries int           = 10
-	defaultBackOffFactor       int           = 2
-	defaultPrefetchCount       int           = 0
+	defaultRecoveryInterval   time.Duration = time.Second
+	defaultMaxRecoveryRetries int           = 10
+	defaultBackOffFactor      int           = 2
+	defaultPrefetchCount      int           = 0
 )
 
 type (
@@ -28,14 +28,14 @@ type (
 	// ConnectionOptions are used to describe how a new connection will be created.
 	ConnectionOptions struct {
 		ReturnHandler
-		loggers             []*slog.Logger
-		Config              *Config
-		codec               *codec
-		uri                 string
-		PrefetchCount       int
-		ReconnectInterval   time.Duration
-		MaxReconnectRetries int
-		BackOffFactor       int
+		loggers            []*slog.Logger
+		Config             *Config
+		codec              *codec
+		uri                string
+		PrefetchCount      int
+		RecoveryInterval   time.Duration
+		MaxRecoveryRetries int
+		BackOffFactor      int
 	}
 
 	// ConnectionSettings holds settings for a broker connection.
@@ -55,10 +55,10 @@ type (
 
 func defaultConnectionOptions(uri string) *ConnectionOptions {
 	return &ConnectionOptions{
-		uri:                 uri,
-		ReconnectInterval:   defaultReconnectInterval,
-		MaxReconnectRetries: defaultMaxReconnectRetries,
-		BackOffFactor:       defaultBackOffFactor,
+		uri:                uri,
+		RecoveryInterval:   defaultRecoveryInterval,
+		MaxRecoveryRetries: defaultMaxRecoveryRetries,
+		BackOffFactor:      defaultBackOffFactor,
 		Config: &Config{
 			Properties: make(amqp.Table),
 		},
@@ -77,7 +77,7 @@ func WithCustomConnectionOptions(options *ConnectionOptions) ConnectionOption {
 	return func(opt *ConnectionOptions) {
 		if options != nil {
 			opt.PrefetchCount = options.PrefetchCount
-			opt.ReconnectInterval = options.ReconnectInterval
+			opt.RecoveryInterval = options.RecoveryInterval
 
 			if options.Config != nil {
 				opt.Config = options.Config
@@ -160,18 +160,18 @@ func WithConnectionOptionReturnHandler(returnHandler ReturnHandler) ConnectionOp
 	return func(options *ConnectionOptions) { options.ReturnHandler = returnHandler }
 }
 
-// WithConnectionOptionReconnectInterval sets the initial reconnection interval.
+// WithConnectionOptionRecoveryInterval sets the initial recovery interval.
 //
 // Default: 1s.
-func WithConnectionOptionReconnectInterval(interval time.Duration) ConnectionOption {
-	return func(options *ConnectionOptions) { options.ReconnectInterval = interval }
+func WithConnectionOptionRecoveryInterval(interval time.Duration) ConnectionOption {
+	return func(options *ConnectionOptions) { options.RecoveryInterval = interval }
 }
 
-// WithConnectionOptionMaxReconnectRetries sets the limit for maximum retries.
+// WithConnectionOptionMaxRecoveryRetries sets the limit for maximum retries.
 //
 // Default: 10.
-func WithConnectionOptionMaxReconnectRetries(maxRetries int) ConnectionOption {
-	return func(options *ConnectionOptions) { options.MaxReconnectRetries = maxRetries }
+func WithConnectionOptionMaxRecoveryRetries(maxRetries int) ConnectionOption {
+	return func(options *ConnectionOptions) { options.MaxRecoveryRetries = maxRetries }
 }
 
 // WithConnectionOptionBackOffFactor sets the exponential back-off factor.

--- a/consume_options.go
+++ b/consume_options.go
@@ -23,6 +23,7 @@ const (
 )
 
 type (
+	// ConsumeOption is an option for a Consumer.
 	ConsumeOption func(*ConsumeOptions)
 
 	// ConsumeOptions are used to describe how a new consumer will be configured.

--- a/consume_options.go
+++ b/consume_options.go
@@ -56,8 +56,7 @@ type (
 		dlqNameBase    string
 	}
 
-	// ConsumerOptions are used to configure the consumer
-	// on the rabbit server.
+	// ConsumerOptions are used to configure the consumer.
 	ConsumerOptions struct {
 		// Application or exchange specific fields,
 		// the headers exchange will inspect this field.
@@ -68,7 +67,7 @@ type (
 		AutoAck bool
 		// Ensures that this is the sole consumer from the queue.
 		Exclusive bool
-		// If true, the client does not wait for a reply method. If the server could not complete the method it will raise a channel or connection exception.
+		// If true, the client does not wait for a reply method. If the broker could not complete the method it will raise a channel or connection exception.
 		NoWait bool
 	}
 )
@@ -292,7 +291,7 @@ func WithConsumerOptionHandlerQuantity(concurrency int) ConsumeOption {
 	}
 }
 
-// WithConsumerOptionConsumerName sets the name on the server of this consumer.
+// WithConsumerOptionConsumerName sets the name of the consumer.
 //
 // If unset a random name will be given.
 func WithConsumerOptionConsumerName(consumerName string) ConsumeOption {
@@ -328,7 +327,7 @@ func WithConsumerOptionDeadLetterRetry(options *RetryOptions) ConsumeOption {
 	}
 }
 
-// WithConsumerOptionConsumerAutoAck sets the auto acknowledge property on the server of this consumer.
+// WithConsumerOptionConsumerAutoAck sets the auto acknowledge property of the consumer.
 //
 // Default: false.
 func WithConsumerOptionConsumerAutoAck(autoAck bool) ConsumeOption {
@@ -336,8 +335,8 @@ func WithConsumerOptionConsumerAutoAck(autoAck bool) ConsumeOption {
 }
 
 // WithConsumerOptionConsumerExclusive sets the exclusive property of this consumer, which means
-// the server will ensure that this is the only consumer
-// from this queue. When exclusive is false, the server will fairly distribute
+// the broker will ensure that this is the only consumer
+// from this queue. When exclusive is false, the broker will fairly distribute
 // deliveries across multiple consumers.
 //
 // Default: false.
@@ -346,7 +345,7 @@ func WithConsumerOptionConsumerExclusive(exclusive bool) ConsumeOption {
 }
 
 // WithConsumerOptionNoWait sets the exclusive no-wait property of this consumer, which means
-// it does not wait for the server to confirm the request and
+// it does not wait for the broker to confirm the request and
 // immediately begin deliveries. If it is not possible to consume, a channel
 // exception will be raised and the channel will be closed.
 //

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
-var ErrNoActiveConnection = errors.New("no active connection to rabbitmq")
+var ErrNoActiveConnection = errors.New("no active connection to broker")
 
 // ErrPublishFailedChannelClosed occurs when the channel is accessed while being closed.
 var ErrPublishFailedChannelClosed = errors.New("channel is closed")
@@ -25,6 +25,7 @@ var ErrHealthyConnection = errors.New("connection is healthy, no need to reconne
 // ErrInvalidConnection occurs when an invalid connection is passed to a publisher or a consumer.
 var ErrInvalidConnection = errors.New("invalid connection")
 
+// AMQPError is a custom error type that wraps amqp errors.
 type AMQPError amqp.Error
 
 func (e *AMQPError) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -19,8 +19,8 @@ var ErrPublishFailedChannelClosedCached = errors.New("channel is closed: publish
 // ErrMaxRetriesExceeded occurs when the maximum number of retries exceeds.
 var ErrMaxRetriesExceeded = errors.New("max retries exceeded")
 
-// ErrHealthyConnection occurs when a manual reconnect is triggered but the connection persists.
-var ErrHealthyConnection = errors.New("connection is healthy, no need to reconnect")
+// ErrHealthyConnection occurs when a manual recovery is triggered but the connection persists.
+var ErrHealthyConnection = errors.New("connection is healthy, no need to recover")
 
 // ErrInvalidConnection occurs when an invalid connection is passed to a publisher or a consumer.
 var ErrInvalidConnection = errors.New("invalid connection")

--- a/errors.go
+++ b/errors.go
@@ -10,8 +10,11 @@ import (
 // ErrNoActiveConnection occurs when there is no active connection while trying to get the failed recovery notification channel.
 var ErrNoActiveConnection = errors.New("no active connection to rabbitmq")
 
-// ErrChannelClosed occurs when the channel accessed but is closed.
-var ErrChannelClosed = errors.New("amqp channel is closed")
+// ErrPublishFailedChannelClosed occurs when the channel is accessed while being closed.
+var ErrPublishFailedChannelClosed = errors.New("channel is closed")
+
+// ErrPublishFailedChannelClosedCached occurs when the channel is accessed while being closed but publishing was cached.
+var ErrPublishFailedChannelClosedCached = errors.New("channel is closed: publishing was cached")
 
 // ErrMaxRetriesExceeded occurs when the maximum number of retries exceeds.
 var ErrMaxRetriesExceeded = errors.New("max retries exceeded")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Clarilab/clarimq
 
-go 1.21
+go 1.21.1
 
 require github.com/rabbitmq/amqp091-go v1.8.1

--- a/publish.go
+++ b/publish.go
@@ -231,7 +231,7 @@ func (publisher *Publisher) watchCheckPublishingCacheChan() {
 					continue
 				}
 
-				if err := publisher.publishCachedMessages(context.Background(), cacheLen); err != nil {
+				if err := publisher.PublishCachedMessages(context.Background(), cacheLen); err != nil {
 					publisher.conn.errChanMU.Lock()
 					publisher.conn.errChan <- err
 					publisher.conn.errChanMU.Unlock()
@@ -243,7 +243,7 @@ func (publisher *Publisher) watchCheckPublishingCacheChan() {
 
 var ErrCacheNotSet = fmt.Errorf("publishing cache is not set")
 
-func (publisher *Publisher) publishCachedMessages(ctx context.Context, cacheLen int) error {
+func (publisher *Publisher) PublishCachedMessages(ctx context.Context, cacheLen int) error {
 	const errMessage = "failed to publish cached messages: %w"
 
 	if publisher.options.PublishingCache == nil {

--- a/publish.go
+++ b/publish.go
@@ -169,7 +169,7 @@ func (publisher *Publisher) sendMessage(ctx context.Context, routingKeys []strin
 			options.Exchange,
 			key,
 			options.Mandatory,
-			false, // always set to false since rabbitmq does not support immediate publishing
+			false, // always set to false since RabbitMQ does not support immediate publishing
 			message,
 		); err != nil {
 			return fmt.Errorf(errMessage, err)

--- a/publish_options.go
+++ b/publish_options.go
@@ -6,7 +6,7 @@ import (
 
 type (
 	// PublishingCache is an interface for a cache of messages that
-	// could not be published due to a missing server connection.
+	// could not be published due to a missing broker connection.
 	PublishingCache interface {
 		// Put adds a publishing to the cache.
 		Put(Publishing) error
@@ -147,7 +147,7 @@ func WithPublishOptionContentType(contentType string) PublisherOption {
 
 // WithPublishOptionDeliveryMode sets the message delivery mode. Transient messages will
 // not be restored to durable queues, persistent messages will be restored to
-// durable queues and lost on non-durable queues during server restart. By default publishing's
+// durable queues and lost on non-durable queues during broker restart. By default publishing's
 // are transient.
 func WithPublishOptionDeliveryMode(deliveryMode DeliveryMode) PublisherOption {
 	return func(options *PublisherOptions) { options.PublishingOptions.DeliveryMode = deliveryMode }

--- a/publish_options.go
+++ b/publish_options.go
@@ -5,7 +5,29 @@ import (
 )
 
 type (
-	PublishOption func(*PublishOptions)
+	// PublishingCache is an interface for a cache of messages that
+	// could not be published due to a missing server connection.
+	PublishingCache interface {
+		// Put adds a publishing to the cache.
+		Put(Publishing) error
+		// PopAll gets all publishing's from the cache and removes them.
+		PopAll() ([]Publishing, error)
+		// Len returns the number of publishing in the cache.
+		Len() int
+		// Flush removes all publishing's from the cache.
+		Flush() error
+	}
+
+	// PublisherOptions are the options for a publisher.
+	PublisherOptions struct {
+		// PublishingCache is the publishing cache.
+		PublishingCache PublishingCache
+		// PublishingOptions are the options for publishing messages.
+		PublishingOptions *PublishOptions
+	}
+
+	// PublisherOption is an option for a Publisher.
+	PublisherOption func(*PublisherOptions)
 
 	// PublishOptions are used to control how data is published.
 	PublishOptions struct {
@@ -45,6 +67,13 @@ type (
 	}
 )
 
+func defaultPublisherOptions() *PublisherOptions {
+	return &PublisherOptions{
+		PublishingCache:   nil,
+		PublishingOptions: defaultPublishOptions(),
+	}
+}
+
 func defaultPublishOptions() *PublishOptions {
 	return &PublishOptions{
 		Headers:         make(Table),
@@ -67,109 +96,122 @@ func defaultPublishOptions() *PublishOptions {
 // WithCustomPublishOptions sets the publish options.
 //
 // It can be used to set all publisher options at once.
-func WithCustomPublishOptions(options *PublishOptions) PublishOption {
-	return func(opt *PublishOptions) {
+func WithCustomPublishOptions(options *PublisherOptions) PublisherOption {
+	return func(opt *PublisherOptions) {
 		if options != nil {
-			opt.AppID = options.AppID
-			opt.ContentEncoding = options.ContentEncoding
-			opt.ContentType = options.ContentType
-			opt.CorrelationID = options.CorrelationID
-			opt.DeliveryMode = options.DeliveryMode
-			opt.Exchange = options.Exchange
-			opt.Expiration = options.Expiration
-			opt.Mandatory = options.Mandatory
-			opt.MessageID = options.MessageID
-			opt.Priority = options.Priority
-			opt.ReplyTo = options.ReplyTo
-			opt.Timestamp = options.Timestamp
-			opt.Type = options.Type
-			opt.UserID = options.UserID
+			if options.PublishingOptions != nil {
+				opt.PublishingOptions.AppID = options.PublishingOptions.AppID
+				opt.PublishingOptions.ContentEncoding = options.PublishingOptions.ContentEncoding
+				opt.PublishingOptions.ContentType = options.PublishingOptions.ContentType
+				opt.PublishingOptions.CorrelationID = options.PublishingOptions.CorrelationID
+				opt.PublishingOptions.DeliveryMode = options.PublishingOptions.DeliveryMode
+				opt.PublishingOptions.Exchange = options.PublishingOptions.Exchange
+				opt.PublishingOptions.Expiration = options.PublishingOptions.Expiration
+				opt.PublishingOptions.Mandatory = options.PublishingOptions.Mandatory
+				opt.PublishingOptions.MessageID = options.PublishingOptions.MessageID
+				opt.PublishingOptions.Priority = options.PublishingOptions.Priority
+				opt.PublishingOptions.ReplyTo = options.PublishingOptions.ReplyTo
+				opt.PublishingOptions.Timestamp = options.PublishingOptions.Timestamp
+				opt.PublishingOptions.Type = options.PublishingOptions.Type
+				opt.PublishingOptions.UserID = options.PublishingOptions.UserID
 
-			if options.Headers != nil {
-				opt.Headers = options.Headers
+				if options.PublishingOptions.Headers != nil {
+					opt.PublishingOptions.Headers = options.PublishingOptions.Headers
+				}
+			}
+
+			if options.PublishingCache != nil {
+				opt.PublishingCache = options.PublishingCache
 			}
 		}
 	}
 }
 
 // WithPublishOptionExchange sets the exchange to publish to.
-func WithPublishOptionExchange(exchange string) PublishOption {
-	return func(options *PublishOptions) { options.Exchange = exchange }
+func WithPublishOptionExchange(exchange string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Exchange = exchange }
 }
 
 // WithPublishOptionMandatory sets whether the publishing is mandatory, which means when a queue is not
 // bound to the routing key a message will be sent back on the returns channel for you to handle.
 //
 // Default: false.
-func WithPublishOptionMandatory(mandatory bool) PublishOption {
-	return func(options *PublishOptions) { options.Mandatory = mandatory }
+func WithPublishOptionMandatory(mandatory bool) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Mandatory = mandatory }
 }
 
 // WithPublishOptionContentType sets the content type, i.e. "application/json".
-func WithPublishOptionContentType(contentType string) PublishOption {
-	return func(options *PublishOptions) { options.ContentType = contentType }
+func WithPublishOptionContentType(contentType string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.ContentType = contentType }
 }
 
 // WithPublishOptionDeliveryMode sets the message delivery mode. Transient messages will
 // not be restored to durable queues, persistent messages will be restored to
 // durable queues and lost on non-durable queues during server restart. By default publishing's
 // are transient.
-func WithPublishOptionDeliveryMode(deliveryMode DeliveryMode) PublishOption {
-	return func(options *PublishOptions) { options.DeliveryMode = deliveryMode }
+func WithPublishOptionDeliveryMode(deliveryMode DeliveryMode) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.DeliveryMode = deliveryMode }
 }
 
 // WithPublishOptionExpiration sets the expiry/TTL of a message. As per RabbitMq spec, it must be a.
 // string value in milliseconds.
-func WithPublishOptionExpiration(expiration string) PublishOption {
-	return func(options *PublishOptions) { options.Expiration = expiration }
+func WithPublishOptionExpiration(expiration string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Expiration = expiration }
 }
 
 // WithPublishOptionHeaders sets message header values, i.e. "msg-id".
-func WithPublishOptionHeaders(headers Table) PublishOption {
-	return func(options *PublishOptions) { options.Headers = headers }
+func WithPublishOptionHeaders(headers Table) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Headers = headers }
 }
 
 // WithPublishOptionContentEncoding sets the content encoding, i.e. "utf-8".
-func WithPublishOptionContentEncoding(contentEncoding string) PublishOption {
-	return func(options *PublishOptions) { options.ContentEncoding = contentEncoding }
+func WithPublishOptionContentEncoding(contentEncoding string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.ContentEncoding = contentEncoding }
 }
 
 // WithPublishOptionPriority sets the content priority from 0 to 9.
-func WithPublishOptionPriority(priority Priority) PublishOption {
-	return func(options *PublishOptions) { options.Priority = priority }
+func WithPublishOptionPriority(priority Priority) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Priority = priority }
 }
 
 // WithPublishOptionTracing sets the content correlation identifier.
-func WithPublishOptionTracing(correlationID string) PublishOption {
-	return func(options *PublishOptions) { options.CorrelationID = correlationID }
+func WithPublishOptionTracing(correlationID string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.CorrelationID = correlationID }
 }
 
 // WithPublishOptionReplyTo sets the reply to field.
-func WithPublishOptionReplyTo(replyTo string) PublishOption {
-	return func(options *PublishOptions) { options.ReplyTo = replyTo }
+func WithPublishOptionReplyTo(replyTo string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.ReplyTo = replyTo }
 }
 
 // WithPublishOptionMessageID sets the message identifier.
-func WithPublishOptionMessageID(messageID string) PublishOption {
-	return func(options *PublishOptions) { options.MessageID = messageID }
+func WithPublishOptionMessageID(messageID string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.MessageID = messageID }
 }
 
 // WithPublishOptionTimestamp sets the timestamp for the message.
-func WithPublishOptionTimestamp(timestamp time.Time) PublishOption {
-	return func(options *PublishOptions) { options.Timestamp = timestamp }
+func WithPublishOptionTimestamp(timestamp time.Time) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Timestamp = timestamp }
 }
 
 // WithPublishOptionType sets the message type name.
-func WithPublishOptionType(messageType string) PublishOption {
-	return func(options *PublishOptions) { options.Type = messageType }
+func WithPublishOptionType(messageType string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.Type = messageType }
 }
 
 // WithPublishOptionUserID sets the user id e.g. "user".
-func WithPublishOptionUserID(userID string) PublishOption {
-	return func(options *PublishOptions) { options.UserID = userID }
+func WithPublishOptionUserID(userID string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.UserID = userID }
 }
 
 // WithPublishOptionAppID sets the application id.
-func WithPublishOptionAppID(appID string) PublishOption {
-	return func(options *PublishOptions) { options.AppID = appID }
+func WithPublishOptionAppID(appID string) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingOptions.AppID = appID }
+}
+
+// WithPublisherOptionPublishingCache enables the publishing cache.
+//
+// An implementation of the PublishingCache interface must be provided.
+func WithPublisherOptionPublishingCache(cache PublishingCache) PublisherOption {
+	return func(options *PublisherOptions) { options.PublishingCache = cache }
 }

--- a/publishing.go
+++ b/publishing.go
@@ -1,0 +1,36 @@
+package clarimq
+
+// Publishing is an interface for messages that are published to a broker.
+type Publishing interface {
+	ID() string
+	GetTargets() []string
+	GetData() any
+	GetOptions() *PublishOptions
+}
+
+type publishing struct {
+	PublishingID string
+	Targets      []string
+	Data         any
+	Options      *PublishOptions
+}
+
+// ID implements the Publishing interface.
+func (p *publishing) ID() string {
+	return p.PublishingID
+}
+
+// GetTargets implements the Publishing interface.
+func (p *publishing) GetTargets() []string {
+	return p.Targets
+}
+
+// GetData implements the Publishing interface.
+func (p *publishing) GetData() any {
+	return p.Data
+}
+
+// GetOptions implements the Publishing interface.
+func (p *publishing) GetOptions() *PublishOptions {
+	return p.Options
+}

--- a/queue.go
+++ b/queue.go
@@ -20,9 +20,9 @@ type QueueOptions struct {
 	AutoDelete bool
 	// If true, the queue is used by only one connection and will be deleted when that connection closes.
 	Exclusive bool
-	// If true, the client does not wait for a reply method. If the server could not complete the method it will raise a channel or connection exception.
+	// If true, the client does not wait for a reply method. If the broker could not complete the method it will raise a channel or connection exception.
 	NoWait bool
-	// If false, a missing queue will be created on the server.
+	// If false, a missing queue will be created on the broker.
 	Passive bool
 	// If true, the queue will be declared if it does not already exist.
 	Declare bool
@@ -48,33 +48,29 @@ func declareQueue(channel *amqp.Channel, options *QueueOptions) error {
 		return nil
 	}
 
-	var err error
-
 	if options.Passive {
-		_, err = channel.QueueDeclarePassive(
+		if _, err := channel.QueueDeclarePassive(
 			options.name,
 			options.Durable,
 			options.AutoDelete,
 			options.Exclusive,
 			options.NoWait,
 			amqp.Table(options.Args),
-		)
-		if err != nil {
+		); err != nil {
 			return fmt.Errorf(errMessage, err)
 		}
 
 		return nil
 	}
 
-	_, err = channel.QueueDeclare(
+	if _, err := channel.QueueDeclare(
 		options.name,
 		options.Durable,
 		options.AutoDelete,
 		options.Exclusive,
 		options.NoWait,
 		amqp.Table(options.Args),
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf(errMessage, err)
 	}
 

--- a/random.go
+++ b/random.go
@@ -12,9 +12,8 @@ const (
 func newRandomString() string {
 	bytes := make([]byte, defaultLength)
 
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return ""
+	if _, err := rand.Read(bytes); err != nil {
+		panic(err)
 	}
 
 	return hex.EncodeToString(bytes)


### PR DESCRIPTION
- Adds functionality to cache messages, that are send while broker downtime (while the client is recovering) to publish them after the connection is reestablished.
The cache itself is an interface, that can be implemented by the user. The user could for example implement caching to something like redis or some other storage of choice.

- Adds a sub package, which holds a basic "In-Memory-Cache" implementation that can be used f.e. for testing but also for production.
- Updates the README.md
- Fixes some ambiguous naming
- Updates GO version to 1.21.1 (govulncheck found some vulns in 1.21.0)