### PR TITLE
feat: add getting connection name and accept logger interface

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ">=1.21.0"
 

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -1033,7 +1033,7 @@ func Test_Integration_ReturnHandler(t *testing.T) {
 	err = publisher.Publish(context.Background(), "does-not-exist", message)
 	requireNoError(t, err)
 
-	// the publishing is retured to the return handler.
+	// the publishing is returned to the return handler.
 
 	// waiting for the return handler to process the message.
 	<-doneChan
@@ -1186,6 +1186,40 @@ func Test_Integration_DeadLetterRetry(t *testing.T) {
 			requireNoError(t, err)
 		})
 	}
+}
+
+func Test_Integration_ConnectionName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connection name is set", func(t *testing.T) {
+		t.Parallel()
+
+		conn := getConnection(t, clarimq.WithConnectionOptionConnectionName("connection-name"))
+		t.Cleanup(func() {
+			if err := conn.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+
+		if conn.Name() != "connection-name" {
+			t.Errorf("expected connection name to be 'connection-name', got: '%s'", conn.Name())
+		}
+	})
+
+	t.Run("connection name is not set", func(t *testing.T) {
+		t.Parallel()
+
+		conn := getConnection(t)
+		t.Cleanup(func() {
+			if err := conn.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+
+		if !strings.Contains(conn.Name(), "connection_") {
+			t.Errorf("expected connection name to contain 'connection_', got: '%s'", conn.Name())
+		}
+	})
 }
 
 // testBuffer is used as buffer for the logging io.Writer

--- a/connection.go
+++ b/connection.go
@@ -107,6 +107,15 @@ func (c *Connection) Close() error {
 	return nil
 }
 
+// Name returns the name of the connection if specified, otherwise returns an empty string.
+func (c *Connection) Name() string {
+	if name, ok := c.options.Config.Properties[amqpConnectionNameKey].(string); ok {
+		return name
+	}
+
+	return ""
+}
+
 // NotifyErrors returns a channel that will return an errors that happen concurrently.
 func (c *Connection) NotifyErrors() <-chan error {
 	return c.errChan
@@ -328,7 +337,7 @@ func (c *Connection) handleClosedConnection(err *amqp.Error) {
 
 	if err := c.recoverConnection(); err != nil {
 		c.errChanMU.Lock()
-		c.errChan <- &RecoveryFailedError{err}
+		c.errChan <- &RecoveryFailedError{err, c.Name()}
 		c.errChanMU.Unlock()
 	}
 }
@@ -352,7 +361,7 @@ func (c *Connection) handleClosedChannel(err *amqp.Error) {
 
 	if err := c.recoverChannel(); err != nil {
 		c.errChanMU.Lock()
-		c.errChan <- &RecoveryFailedError{err}
+		c.errChan <- &RecoveryFailedError{err, c.Name()}
 		c.errChanMU.Unlock()
 	}
 }

--- a/connection_options.go
+++ b/connection_options.go
@@ -10,10 +10,12 @@ import (
 )
 
 const (
-	defaultRecoveryInterval   time.Duration = time.Second
-	defaultMaxRecoveryRetries int           = 10
-	defaultBackOffFactor      int           = 2
-	defaultPrefetchCount      int           = 0
+	defaultRecoveryInterval     time.Duration = time.Second
+	defaultMaxRecoveryRetries   int           = 10
+	defaultBackOffFactor        int           = 2
+	defaultPrefetchCount        int           = 0
+	defaultConnectionNamePrefix string        = "connection_"
+	amqpConnectionNameKey       string        = "connection_name"
 )
 
 type (
@@ -60,7 +62,9 @@ func defaultConnectionOptions(uri string) *ConnectionOptions {
 		MaxRecoveryRetries: defaultMaxRecoveryRetries,
 		BackOffFactor:      defaultBackOffFactor,
 		Config: &Config{
-			Properties: make(amqp.Table),
+			Properties: amqp.Table{
+				amqpConnectionNameKey: defaultConnectionNamePrefix + newRandomString(),
+			},
 		},
 		PrefetchCount: defaultPrefetchCount,
 		codec: &codec{

--- a/connection_options.go
+++ b/connection_options.go
@@ -2,8 +2,6 @@ package clarimq
 
 import (
 	"encoding/json"
-	"io"
-	"log/slog"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -30,7 +28,7 @@ type (
 	// ConnectionOptions are used to describe how a new connection will be created.
 	ConnectionOptions struct {
 		ReturnHandler
-		loggers            []*slog.Logger
+		loggers            []Logger
 		Config             *Config
 		codec              *codec
 		uri                string
@@ -99,36 +97,8 @@ func WithConnectionOptionConnectionName(name string) ConnectionOption {
 	return func(options *ConnectionOptions) { options.Config.Properties.SetClientConnectionName(name) }
 }
 
-// WithConnectionOptionTextLogging enables structured text logging to the given writer.
-func WithConnectionOptionTextLogging(w io.Writer, logLevel slog.Level) ConnectionOption {
-	return func(o *ConnectionOptions) {
-		o.loggers = append(o.loggers,
-			slog.New(slog.NewTextHandler(
-				w,
-				&slog.HandlerOptions{
-					Level: logLevel,
-				},
-			)),
-		)
-	}
-}
-
-// WithConnectionOptionJSONLogging enables structured json logging to the given writer.
-func WithConnectionOptionJSONLogging(w io.Writer, logLevel slog.Level) ConnectionOption {
-	return func(o *ConnectionOptions) {
-		o.loggers = append(o.loggers,
-			slog.New(slog.NewJSONHandler(
-				w,
-				&slog.HandlerOptions{
-					Level: logLevel,
-				},
-			)),
-		)
-	}
-}
-
-// WithConnectionOptionMultipleLoggers adds multiple loggers.
-func WithConnectionOptionMultipleLoggers(loggers []*slog.Logger) ConnectionOption {
+// WithConnectionOptionLoggers adds multiple loggers.
+func WithConnectionOptionLoggers(loggers ...Logger) ConnectionOption {
 	return func(o *ConnectionOptions) {
 		o.loggers = append(o.loggers, loggers...)
 	}
@@ -186,7 +156,7 @@ func WithConnectionOptionBackOffFactor(factor int) ConnectionOption {
 }
 
 // SetLoggers provides possibility to add loggers.
-func (c *Connection) SetLoggers(loggers []*slog.Logger) {
+func (c *Connection) SetLoggers(loggers ...Logger) {
 	if len(loggers) > 0 {
 		c.options.loggers = loggers
 	}

--- a/errors.go
+++ b/errors.go
@@ -34,17 +34,18 @@ func (e *AMQPError) Error() string {
 
 // ErrRecoveryFailed occurs when the recovery failed after a connection loss.
 type RecoveryFailedError struct {
-	Err error
+	Err            error
+	ConnectionName string
 }
 
 // Error implements the Error method of the error interface.
 func (e *RecoveryFailedError) Error() string {
-	var str string
+	str := fmt.Sprintf("failed to recover %s:", e.ConnectionName)
 
 	if e.Err != nil {
-		str = e.Err.Error()
+		str += e.Err.Error()
 	} else {
-		str = "unknown error"
+		str += "unknown error"
 	}
 
 	return str

--- a/logging.go
+++ b/logging.go
@@ -1,14 +1,18 @@
 package clarimq
 
-import (
-	"log/slog"
-)
-
-type logger struct {
-	loggers []*slog.Logger
+// Logger is an interface that is be used for log messages.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Error(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
 }
 
-func newLogger(loggers []*slog.Logger) *logger {
+type logger struct {
+	loggers []Logger
+}
+
+func newLogger(loggers []Logger) *logger {
 	return &logger{loggers}
 }
 


### PR DESCRIPTION
- sets a default connection name 
- adds functionality to get the name from the connection instance
- adds the name to the recovery error, to identify which connection caused the error fe. for logging purposes
- accepts a logger interface now
- cleans up some option funcs
- adds / adjusts tests
- upgrades setup-go action in pipline