### PR TITLE
fix: handling consumers using a connection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,9 +31,13 @@ jobs:
     # - name: Lint
     #   uses: golangci/golangci-lint-action@v3
 
+    # there is an currently an issue with "enforce-repeated-arg-type-style".
+    # we should probably be able the latest version when golangci-lint v1.56.1 is released.
+    # https://github.com/golangci/golangci-lint/issues/4353
+
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
         golangci-lint run --out-format=github-actions
 
     - name: Vulnerability Check


### PR DESCRIPTION
- Fixes internal handling of consumers using a connection
- Previously: When closing a consumer and later re-declaring him (with the same consumerTag) f.e. due to a recovery, the already closed consumer got also redeclared because he received a signal to recover itself since his go-routine to watch the connection "recoverConsumerChan" channel was still running, which raised an exception in RabbitMQ that closed the channel. This then resulted in a panic (closedChannel) whenever the channel got used afterwards.