### PR TITLE
feat: V2 - start consumers separately

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,30 +21,21 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ">=1.21.0"
+        go-version: ">=1.22.4"
 
     - name: Vet
       run: make vet
 
-    # the official golanci-lint-action logs a lot of errors (https://github.com/golangci/golangci-lint-action/issues/135)
-    # therefore it's replaced with a manual approach
-    # - name: Lint
-    #   uses: golangci/golangci-lint-action@v3
-
-    # there is an currently an issue with "enforce-repeated-arg-type-style".
-    # we should probably be able the latest version when golangci-lint v1.56.1 is released.
-    # https://github.com/golangci/golangci-lint/issues/4353
-
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
         golangci-lint run --out-format=github-actions
 
     - name: Vulnerability Check
       uses: golang/govulncheck-action@v1
       with:
         go-package: ./...
-        go-version-input: ">=1.21.0"
+        go-version-input: ">=1.22.4"
         check-latest: true
 
     - name: Integration Tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,28 +2,18 @@ linters:
   enable-all: true
   disable:
     - contextcheck # Check whether the function uses a non-inherited context aka context.Background()
-    - deadcode # deprecated, replaced by unused
     - depguard # not needed, does the same as gomodguard
     - execinquery # sql linter, no need
     - exhaustruct # very annoying, checks if all struct fields are filled
-    - exhaustivestruct # deprecated, same as exhaustruct
     - ginkgolinter # not used libs
     - godot # nervig für quasi keinen impact
     - gofumpt # we don't use gofumpt
     - goheader # unused
-    - golint # deprecated, replaced by revive
-    - ifshort # deprecated
-    - interfacer # deprecated
     - lll # should be disabled in CI, as this is cosmetic only
-    - maligned # deprecated
     - nakedret # no need
-    - nosnakecase # deprecated
     - rowserrcheck # disabled because sql
-    - scopelint # deprecated
-    - structcheck # deprecated & disabled because of generics
     - sqlclosecheck # disabled because of generics
     - tagliatelle # requires ID instead of Id in jsonTags, which is annoying for our old structs
-    - varcheck  # deprecated
 linters-settings:
   cyclop:
     max-complexity: 20
@@ -69,7 +59,7 @@ linters-settings:
         replacement: 'a[b:]'
       - pattern: 'a[0:b]'
         replacement: 'a[:b]'
-  gomnd:
+  mnd:
     # List of function patterns to exclude from analysis.
     # Values always ignored: `time.Date`,
     # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
@@ -134,7 +124,7 @@ linters-settings:
   revive:
     enable-all-rules: true
     rules:
-      # Provided by gomnd linter
+      # Provided by mnd linter
       - name: add-constant
         disabled: true
       - name: argument-limit
@@ -231,14 +221,14 @@ issues:
         - funlen
         - goconst
         - gocyclo
-        - gomnd
+        - mnd
         - gosec
         - noctx
         - wrapcheck
 output:
   sort-results: true
 run:
-  skip-dirs:
+  exclude-dirs:
     - cmd
     - config
   # tests: false

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This library includes support for:
 
 Supported Go Versions
 
-This library supports the most recent Go, currently 1.21.1
+This library supports the most recent Go, currently 1.22.4
 
 ## INSTALL
 
 ```bash
-go get github.com/Clarilab/clarimq
+go get github.com/Clarilab/clarimq/v2
 ```
 
 ## USAGE
@@ -174,7 +174,26 @@ consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
 if err != nil {
 	// handle error
 }
+
+err := consumer.Start()
+if err != nil {
+	// handle error
+}
 ```
+
+The consumer can be set up to immediately start consuming messages from the broker by using the **WithConsumerOptionConsumeAfterCreation** option.
+The consumer then does not need to be started with the **Start** method. An error will be returned when trying to start an already started/running consumer.
+##### Example 
+```Go
+consumer, err := clarimq.NewConsumer(conn, "my-queue", handler(),
+		clarimq.WithConsumerOptionConsumeAfterCreation(true),
+	// more options can be passed
+)
+if err != nil {
+	// handle error
+}
+```
+
 
 The consumer can be used to declare exchanges, queues and queue-bindings:
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"sync"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 )
 
 // BasicInMemoryCache is a basic in-memory cache implementation of the clarimq.PublishingCache interface.

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -179,14 +179,6 @@ func Test_Integration_PublishToExchange(t *testing.T) {
 			publishConn := getConnection(t)
 			consumerConn := getConnection(t)
 
-			t.Cleanup(func() {
-				err := publishConn.Close()
-				requireNoError(t, err)
-
-				err = consumerConn.Close()
-				requireNoError(t, err)
-			})
-
 			doneChan := make(chan struct{})
 
 			testParams := &testParams{
@@ -395,14 +387,6 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 
 			publishConn := getConnection(t)
 			consumeConn := getConnection(t)
-
-			t.Cleanup(func() {
-				err := publishConn.Close()
-				requireNoError(t, err)
-
-				err = consumeConn.Close()
-				requireNoError(t, err)
-			})
 
 			doneChan := make(chan struct{})
 			queueName := stringGen()
@@ -666,14 +650,6 @@ func Test_Integration_Consume(t *testing.T) {
 			publishConn := getConnection(t)
 			consumeConn := getConnection(t)
 
-			t.Cleanup(func() {
-				err := publishConn.Close()
-				requireNoError(t, err)
-
-				err = consumeConn.Close()
-				requireNoError(t, err)
-			})
-
 			doneChan := make(chan struct{})
 
 			testParams := &testParams{
@@ -844,14 +820,6 @@ func Test_Integration_CustomOptions(t *testing.T) {
 
 			consumeConn := getConnection(t)
 
-			t.Cleanup(func() {
-				err := test.publishConn.Close()
-				requireNoError(t, err)
-
-				err = consumeConn.Close()
-				requireNoError(t, err)
-			})
-
 			wg := &sync.WaitGroup{}
 
 			// adding 2 to wait for both consumers to handle their deliveries.
@@ -1008,11 +976,6 @@ func Test_Integration_ManualRemoveExchangeQueueAndBindings(t *testing.T) {
 
 			conn := getConnection(t)
 
-			t.Cleanup(func() {
-				err := conn.Close()
-				requireNoError(t, err)
-			})
-
 			consumer, err := test.getConsumer(conn, testParams)
 			requireNoError(t, err)
 
@@ -1049,14 +1012,6 @@ func Test_Integration_ReturnHandler(t *testing.T) {
 	)
 
 	consumerConn := getConnection(t)
-
-	t.Cleanup(func() {
-		err := publishConn.Close()
-		requireNoError(t, err)
-
-		err = consumerConn.Close()
-		requireNoError(t, err)
-	})
 
 	exchangeName := stringGen()
 	queueName := stringGen()
@@ -1145,11 +1100,6 @@ func Test_Integration_DecodeDeliveryBody(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			t.Cleanup(func() {
-				err := test.conn.Close()
-				requireNoError(t, err)
-			})
-
 			var result testData
 
 			err := test.conn.DecodeDeliveryBody(delivery, &result)
@@ -1185,14 +1135,6 @@ func Test_Integration_DeadLetterRetry(t *testing.T) {
 
 			publishConn := getConnection(t)
 			consumeConn := getConnection(t)
-
-			t.Cleanup(func() {
-				err := publishConn.Close()
-				requireNoError(t, err)
-
-				err = consumeConn.Close()
-				requireNoError(t, err)
-			})
 
 			publisher, err := clarimq.NewPublisher(publishConn,
 				clarimq.WithPublishOptionExchange(exchangeName),
@@ -1261,11 +1203,6 @@ func Test_Integration_ConnectionName(t *testing.T) {
 		t.Parallel()
 
 		conn := getConnection(t, clarimq.WithConnectionOptionConnectionName("connection-name"))
-		t.Cleanup(func() {
-			if err := conn.Close(); err != nil {
-				t.Error(err)
-			}
-		})
 
 		if conn.Name() != "connection-name" {
 			t.Errorf("expected connection name to be 'connection-name', got: '%s'", conn.Name())
@@ -1276,11 +1213,6 @@ func Test_Integration_ConnectionName(t *testing.T) {
 		t.Parallel()
 
 		conn := getConnection(t)
-		t.Cleanup(func() {
-			if err := conn.Close(); err != nil {
-				t.Error(err)
-			}
-		})
 
 		if !strings.Contains(conn.Name(), "connection_") {
 			t.Errorf("expected connection name to contain 'connection_', got: '%s'", conn.Name())
@@ -1309,14 +1241,6 @@ func Test_Integration_MaxRetriesExceededHandler(t *testing.T) {
 		clarimq.WithConnectionOptionBackOffFactor(1),
 		clarimq.WithConnectionOptionRecoveryInterval(500*time.Millisecond),
 	)
-
-	t.Cleanup(func() {
-		err := publishConn.Close()
-		requireNoError(t, err)
-
-		err = consumeConn.Close()
-		requireNoError(t, err)
-	})
 
 	t.Run("no error", func(t *testing.T) {
 		t.Parallel()
@@ -1699,14 +1623,6 @@ func Test_Recovery_AutomaticRecovery(t *testing.T) { //nolint:paralleltest // in
 		clarimq.WithConnectionOptionRecoveryInterval(500*time.Millisecond),
 	)
 
-	t.Cleanup(func() {
-		err := publishConn.Close()
-		requireNoError(t, err)
-
-		err = consumeConn.Close()
-		requireNoError(t, err)
-	})
-
 	// msgCounter is used to count the number of deliveries, to compare it afterwords.
 	var msgCounter int
 
@@ -1835,14 +1751,6 @@ func Test_Recovery_AutomaticRecoveryFailedTryManualRecovery(t *testing.T) { //no
 		clarimq.WithConnectionOptionBackOffFactor(1),
 	)
 
-	t.Cleanup(func() {
-		err := publishConn.Close()
-		requireNoError(t, err)
-
-		err = consumeConn.Close()
-		requireNoError(t, err)
-	})
-
 	// msgCounter is used to count the number of deliveries, to compare it afterwords.
 	var msgCounter int
 
@@ -1965,14 +1873,6 @@ func Test_Recovery_PublishingCache(t *testing.T) { //nolint:paralleltest // inte
 		clarimq.WithConnectionOptionRecoveryInterval(500*time.Millisecond),
 	)
 
-	t.Cleanup(func() {
-		err := publishConn.Close()
-		requireNoError(t, err)
-
-		err = consumeConn.Close()
-		requireNoError(t, err)
-	})
-
 	wg := &sync.WaitGroup{}
 
 	wg.Add(1)
@@ -2058,6 +1958,11 @@ func getConnection(t *testing.T, options ...clarimq.ConnectionOption) *clarimq.C
 	)
 
 	requireNoError(t, err)
+
+	t.Cleanup(func() {
+		err := conn.Close()
+		requireNoError(t, err)
+	})
 
 	return conn
 }

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -173,8 +173,6 @@ func Test_Integration_PublishToExchange(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -392,8 +390,6 @@ func Test_Integration_PublishToQueue(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -664,8 +660,6 @@ func Test_Integration_Consume(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -843,8 +837,6 @@ func Test_Integration_CustomOptions(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1005,8 +997,6 @@ func Test_Integration_ManualRemoveExchangeQueueAndBindings(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1152,8 +1142,6 @@ func Test_Integration_DecodeDeliveryBody(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1187,8 +1175,6 @@ func Test_Integration_DeadLetterRetry(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2036,7 +2022,7 @@ func Test_Recovery_PublishingCache(t *testing.T) { //nolint:paralleltest // inte
 	err = exec.Command("docker", "compose", "stop", "rabbitmq").Run()
 	requireNoError(t, err)
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		// publish messages to the queue with while not connected.
 		if err := publisher.Publish(context.Background(), queueName, message); !errors.Is(err, clarimq.ErrPublishFailedChannelClosedCached) {
 			t.Fatal()

--- a/clarimq_test.go
+++ b/clarimq_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Clarilab/clarimq"
-	"github.com/Clarilab/clarimq/cache"
+	"github.com/Clarilab/clarimq/v2"
+	"github.com/Clarilab/clarimq/v2/cache"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 

--- a/connection.go
+++ b/connection.go
@@ -32,11 +32,11 @@ type Connection struct {
 	errChanMU sync.Mutex
 	errChan   chan error
 
-	consumerRecoveryChansMU  sync.Mutex
-	consumerRecoveryChans    map[string]chan error
-	checkPublishingCacheChan chan struct{}
+	consumerRecoverFNsMtx sync.RWMutex
+	consumerRecoverFNs    map[string]func() error
 
-	isPublisher bool
+	publisherCheckCacheFNsMtx sync.RWMutex
+	publisherCheckCacheFNs    map[string]func()
 
 	logger *logger
 
@@ -56,13 +56,13 @@ func NewConnection(uri string, options ...ConnectionOption) (*Connection, error)
 	}
 
 	conn := &Connection{
-		connectionCloseWG:        &sync.WaitGroup{},
-		errChan:                  make(chan error, errChanSize),
-		consumerRecoveryChans:    make(map[string]chan error),
-		checkPublishingCacheChan: make(chan struct{}),
-		logger:                   newLogger(opt.loggers),
-		returnHandler:            opt.ReturnHandler,
-		options:                  opt,
+		connectionCloseWG:      &sync.WaitGroup{},
+		errChan:                make(chan error, errChanSize),
+		consumerRecoverFNs:     make(map[string]func() error),
+		publisherCheckCacheFNs: make(map[string]func()),
+		logger:                 newLogger(opt.loggers),
+		returnHandler:          opt.ReturnHandler,
+		options:                opt,
 	}
 
 	if err := conn.connect(); err != nil {
@@ -102,7 +102,6 @@ func (c *Connection) Close() error {
 		c.connectionCloseWG.Wait()
 
 		close(c.errChan)
-		close(c.checkPublishingCacheChan)
 
 		c.logger.logInfo(logCtx, "gracefully closed connection to the broker")
 	}
@@ -323,6 +322,15 @@ func (c *Connection) createChannel() error {
 	return nil
 }
 
+type channelExec func(func(*amqp.Channel) error) error
+
+func (c *Connection) channelExec(fn func(*amqp.Channel) error) error {
+	c.amqpChanMU.Lock()
+	defer c.amqpChanMU.Unlock()
+
+	return fn(c.amqpChannel)
+}
+
 func (c *Connection) watchConnectionNotifications() {
 	closeChan := c.amqpConnection.NotifyClose(make(chan *amqp.Error))
 	blockChan := c.amqpConnection.NotifyBlocked(make(chan amqp.Blocking))
@@ -413,10 +421,8 @@ func (c *Connection) handleClosedConnection() {
 func (c *Connection) handleClosedChannel(err *amqp.Error) {
 	c.logger.logDebug(context.Background(), "channel unexpectedly closed", "cause", err)
 
-	amqpErr := AMQPError(*err)
-
 	c.errChanMU.Lock()
-	c.errChan <- &amqpErr
+	c.errChan <- err
 	c.errChanMU.Unlock()
 
 	if err := c.recoverChannel(); err != nil {
@@ -461,15 +467,13 @@ func (c *Connection) recoverChannel() error {
 		return fmt.Errorf(errMessage, err)
 	}
 
-	if len(c.consumerRecoveryChans) > 0 {
+	if len(c.consumerRecoverFNs) > 0 {
 		if err := c.recoverConsumers(); err != nil {
 			return fmt.Errorf(errMessage, err)
 		}
 	}
 
-	if c.isPublisher {
-		c.checkPublishingCacheChan <- struct{}{}
-	}
+	c.recoverPublishers()
 
 	c.logger.logDebug(context.Background(), "successfully recovered channel")
 
@@ -477,56 +481,82 @@ func (c *Connection) recoverChannel() error {
 }
 
 func (c *Connection) recoverConsumers() error {
-	const errMessage = "failed to recover consumer %w"
+	const errMessage = "failed to recover consumers: %w"
 
-	for i := range c.consumerRecoveryChans {
-		c.consumerRecoveryChans[i] <- nil
+	c.consumerRecoverFNsMtx.RLock()
+	defer c.consumerRecoverFNsMtx.RUnlock()
 
-		if err := <-c.consumerRecoveryChans[i]; err != nil {
+	for consumerTag := range c.consumerRecoverFNs {
+		if err := c.consumerRecoverFNs[consumerTag](); err != nil {
 			return fmt.Errorf(errMessage, err)
 		}
+
+		c.logger.logDebug(context.Background(), "successfully recovered consumer", "consumerTag", consumerTag)
 	}
 
-	c.logger.logDebug(context.Background(), "successfully recovered consumer")
+	c.logger.logDebug(context.Background(), "successfully recovered consumers")
 
 	return nil
 }
 
-func (c *Connection) addConsumerRecoveryChan(consumerTag string, ch chan error) {
-	c.consumerRecoveryChansMU.Lock()
-	defer c.consumerRecoveryChansMU.Unlock()
+func (c *Connection) addConsumerRecoveryFN(consumerTag string, fn func() error) {
+	c.consumerRecoverFNsMtx.Lock()
+	defer c.consumerRecoverFNsMtx.Unlock()
 
-	c.consumerRecoveryChans[consumerTag] = ch
+	c.consumerRecoverFNs[consumerTag] = fn
 }
 
-func (c *Connection) removeConsumerRecoveryChan(consumerTag string) {
-	c.consumerRecoveryChansMU.Lock()
-	defer c.consumerRecoveryChansMU.Unlock()
+func (c *Connection) removeConsumerRecoveryFN(consumerTag string) {
+	c.consumerRecoverFNsMtx.Lock()
+	defer c.consumerRecoverFNsMtx.Unlock()
 
-	delete(c.consumerRecoveryChans, consumerTag)
+	delete(c.consumerRecoverFNs, consumerTag)
 }
 
 func (c *Connection) cancelConsumer(consumerTag string) error {
 	const errMessage = "failed to cancel consumer: %w"
 
-	c.amqpChanMU.Lock()
-	defer c.amqpChanMU.Unlock()
-
-	if c.amqpChannel == nil || c.amqpChannel.IsClosed() {
+	if c.isClosed() {
 		return fmt.Errorf(errMessage, amqp.ErrClosed)
 	}
+
+	c.amqpChanMU.Lock()
+	defer c.amqpChanMU.Unlock()
 
 	if err := c.amqpChannel.Cancel(consumerTag, false); err != nil {
 		return fmt.Errorf(errMessage, err)
 	}
 
-	c.removeConsumerRecoveryChan(consumerTag)
+	c.removeConsumerRecoveryFN(consumerTag)
 
 	return nil
 }
 
+func (c *Connection) recoverPublishers() {
+	c.publisherCheckCacheFNsMtx.RLock()
+	defer c.publisherCheckCacheFNsMtx.RUnlock()
+
+	for publisherName := range c.publisherCheckCacheFNs {
+		c.publisherCheckCacheFNs[publisherName]()
+	}
+}
+
+func (c *Connection) addPublisherCheckCacheFN(publisherName string, fn func()) {
+	c.publisherCheckCacheFNsMtx.Lock()
+	defer c.publisherCheckCacheFNsMtx.Unlock()
+
+	c.publisherCheckCacheFNs[publisherName] = fn
+}
+
+func (c *Connection) removePublisherCheckCacheFN(publisherName string) {
+	c.publisherCheckCacheFNsMtx.Lock()
+	defer c.publisherCheckCacheFNsMtx.Unlock()
+
+	delete(c.publisherCheckCacheFNs, publisherName)
+}
+
 func (c *Connection) backOff(action func() error) error {
-	const errMessage = "backOff failed %w"
+	const errMessage = "backOff failed: %w"
 
 	retry := 0
 

--- a/connection.go
+++ b/connection.go
@@ -381,11 +381,7 @@ func (c *Connection) watchChannelNotifications() {
 
 				return
 
-			case tag, ok := <-cancelChan:
-				if !ok {
-					continue
-				}
-
+			case tag := <-cancelChan:
 				c.logger.logWarn(logCtx, "cancel exception", "cause", tag)
 
 			case rtn := <-returnChan:

--- a/consume.go
+++ b/consume.go
@@ -139,7 +139,7 @@ func (c *Consumer) startConsuming() error {
 		return fmt.Errorf(errMessage, err)
 	}
 
-	for i := 0; i < c.options.HandlerQuantity; i++ {
+	for range c.options.HandlerQuantity {
 		go c.handlerRoutine(deliveries)
 	}
 

--- a/consume_options.go
+++ b/consume_options.go
@@ -35,6 +35,9 @@ type (
 		Bindings        []Binding
 		// The number of message handlers, that will run concurrently.
 		HandlerQuantity int
+		// If true, the consumer will start consuming messages instantly after successful creation.
+		// Default: false.
+		ConsumeAfterCreation bool
 	}
 
 	// RetryOptions are used to describe how the retry will be configured.
@@ -357,4 +360,10 @@ func WithConsumerOptionConsumerExclusive(exclusive bool) ConsumeOption {
 // Default: false.
 func WithConsumerOptionNoWait(noWait bool) ConsumeOption {
 	return func(options *ConsumeOptions) { options.ConsumerOptions.NoWait = noWait }
+}
+
+// WithConsumerOptionConsumeAfterCreation sets the consume after creation property of the consumer.
+// If true the consumer will immediately start consuming messages from the queue after creation.
+func WithConsumerOptionConsumeAfterCreation(consumeAfterCreation bool) ConsumeOption {
+	return func(options *ConsumeOptions) { options.ConsumeAfterCreation = consumeAfterCreation }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   rabbitmq:
       container_name: rabbitmq
-      image: 'rabbitmq:3.12.2-alpine'
+      image: 'rabbitmq:3.13.3-alpine'
       ports:
         - "5672:5672"
       healthcheck:

--- a/errors.go
+++ b/errors.go
@@ -25,6 +25,9 @@ var ErrHealthyConnection = errors.New("connection is healthy, no need to recover
 // ErrInvalidConnection occurs when an invalid connection is passed to a publisher or a consumer.
 var ErrInvalidConnection = errors.New("invalid connection")
 
+// ErrConsumerAlreadyRunning occurs when the consumer is attempted to be started but already running.
+var ErrConsumerAlreadyRunning = errors.New("consumer is running")
+
 // AMQPError is a custom error type that wraps amqp errors.
 type AMQPError amqp.Error
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/Clarilab/clarimq
+module github.com/Clarilab/clarimq/v2
 
-go 1.21
+go 1.22.4
 
 require github.com/rabbitmq/amqp091-go v1.10.0

--- a/publish_options.go
+++ b/publish_options.go
@@ -1,7 +1,12 @@
 package clarimq
 
 import (
+	"fmt"
 	"time"
+)
+
+const (
+	undefinedPublisher string = "undefined_publisher"
 )
 
 type (
@@ -20,6 +25,8 @@ type (
 
 	// PublisherOptions are the options for a publisher.
 	PublisherOptions struct {
+		// PublisherName is the name of the publisher.
+		PublisherName string
 		// PublishingCache is the publishing cache.
 		PublishingCache PublishingCache
 		// PublishingOptions are the options for publishing messages.
@@ -69,9 +76,14 @@ type (
 
 func defaultPublisherOptions() *PublisherOptions {
 	return &PublisherOptions{
+		PublisherName:     newDefaultPublisherName(),
 		PublishingCache:   nil,
 		PublishingOptions: defaultPublishOptions(),
 	}
+}
+
+func newDefaultPublisherName() string {
+	return fmt.Sprintf("%s_%s", undefinedPublisher, newRandomString())
 }
 
 func defaultPublishOptions() *PublishOptions {
@@ -214,4 +226,13 @@ func WithPublishOptionAppID(appID string) PublisherOption {
 // An implementation of the PublishingCache interface must be provided.
 func WithPublisherOptionPublishingCache(cache PublishingCache) PublisherOption {
 	return func(options *PublisherOptions) { options.PublishingCache = cache }
+}
+
+// WithPublisherOptionPublisherName sets the name of the publisher.
+//
+// If unset a random name will be given.
+func WithPublisherOptionPublisherName(publisherName string) PublisherOption {
+	return func(options *PublisherOptions) {
+		options.PublisherName = publisherName
+	}
 }

--- a/retry.go
+++ b/retry.go
@@ -58,7 +58,7 @@ func (c *Consumer) setupDeadLetterRetry() error {
 	c.options.RetryOptions.dlxName = dlxPrefix + c.options.ExchangeOptions.Name
 	c.options.RetryOptions.dlqNameBase = dlxPrefix + c.options.QueueOptions.name
 
-	if err := declareExchange(c.options.RetryOptions.RetryConn.amqpChannel,
+	if err := declareExchange(c.options.RetryOptions.RetryConn.channelExec,
 		defaultDLXOptions(c.options.RetryOptions.dlxName),
 	); err != nil {
 		return fmt.Errorf(errMessage, err)
@@ -112,7 +112,7 @@ func (c *Consumer) setupDeadLetterQueues() error {
 
 		queueName := fmt.Sprintf("%s_%s", c.options.RetryOptions.dlqNameBase, ttl.String())
 
-		if err := declareQueue(c.options.RetryOptions.RetryConn.amqpChannel,
+		if err := declareQueue(c.options.RetryOptions.RetryConn.channelExec,
 			defaultDLQOptions(
 				queueName,
 				c.options.ExchangeOptions.Name,
@@ -141,7 +141,7 @@ func (c *Consumer) setupDeadLetterQueues() error {
 		},
 	)
 
-	if err := declareBindings(c.options.RetryOptions.RetryConn.amqpChannel, "", "", bindings); err != nil {
+	if err := declareBindings(c.options.RetryOptions.RetryConn.channelExec, "", "", bindings); err != nil {
 		return fmt.Errorf(errMessage, err)
 	}
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -14,7 +14,7 @@ done
 
 echo "Service $CONTAINER is now available"
 
-go test -run "$1" -vet=off -failfast -race -coverprofile=coverage.out
+go test -run "$1" -vet=off -failfast -race -v -coverprofile=coverage.out
 go_test_exit_code=$?
 
 docker-compose down


### PR DESCRIPTION
BREAKING CHANGE:
- consumers now have to be started separately after their declaration 

Why?: when used in services/applications, the main setup might has not yet fully finished initializing, but the consumers already consume messages from the broker, which can lead to panics, and even the app not starting at all.

Note: consumers can be switched back to the previous behaviour by using the
WithConsumerOptionConsumeAfterCreation() option while declaring the
consumer.

Due to the breaking change: 
- bumps up the module version to v2

Also:
- updates readme
- adds tests
- fixes tests
- fixes issues with closing connections
- fixes issues closing consumers
- fixes multiple race conditions when using connections with multiple consumers/publishers